### PR TITLE
Update google-calendar.js

### DIFF
--- a/google-calendar.js
+++ b/google-calendar.js
@@ -160,24 +160,21 @@ function addRow(event, counter, defaultTicket) {
     var ticket       = '';
     var ticketMarkUp = '';
 
+    ticket = defaultTicket;
+
     if (event.description) {
-      // check the description and the meeting title for a ticket
+      // check the description for a ticket
       if (event.description.match(/([A-Za-z]+-[0-9]+)/)) {
         var ticketInDescription = event.description.match(/([A-Za-z]+-[0-9]+)/)[0];
         ticket = ticketInDescription;
       }
+    }
+    if (event.summary) {
+      // check the meeting title for a ticket
       if (event.summary.match(/([A-Za-z]+-[0-9]+)/)) {
         var ticketInTitle = event.summary.match(/([A-Za-z]+-[0-9]+)/)[0];
         ticket = ticketInTitle;
       }
-      // if the event had a description but no ticket was found, set the ticket to the default
-      else if (!ticketInDescription && !ticketInTitle) {
-        ticket = defaultTicket;
-      }
-    }
-    // if the event has no description (or no title), set the ticket to the default
-    else {
-      ticket = defaultTicket;
     }
 
     ticketMarkUp = '<input id="ticket[' + counter + ']" class="form-control" type="text" value="'+ ticket +'"">';
@@ -187,6 +184,7 @@ function addRow(event, counter, defaultTicket) {
   // find out if the user attended the meeting and if they did, check the box next to the meeting
   function checkIfAttended(event) {
     var attended = false;
+    var hasDuration = true;
     if (!event.attendees) {
       attended = true;
     }
@@ -201,7 +199,14 @@ function addRow(event, counter, defaultTicket) {
         }
       }
     }
-    if (attended === true) {
+
+    var startTime = event.start.dateTime;
+    var endTime = event.end.dateTime;
+    if (startTime === endTime) { //only include entries that have a duration
+      hasDuration = false;
+    } 
+
+    if (attended === true && hasDuration === true) {
       var checkBoxMarkUp = '<input id="checkbox[' + counter + ']" type="checkbox" checked> <label for="checkbox[' + counter + ']"></label>';
     }
     else {
@@ -300,13 +305,13 @@ function formatTimeForAPI(time) {
   var endOfTime = time.match(/\d\d[-\+]\d\d:\d\d/);
   endOfTime = endOfTime[0].replace(':', '');
   time = time.replace(/\d\d[-\+]\d\d:\d\d/, endOfTime);
-
   // then add milliseconds
   startOfTime = time.split(/[-\+]\d\d\d\d/)[0];
   endOfTime   = time.split(/T\d\d:\d\d:\d\d/)[1];
   startOfTime = startOfTime + '.000';
 
-  time = startOfTime + endOfTime;
+  // Jira doesn't seem to like including the timezone, so it's commented below
+  time = startOfTime + '+0000'; //+ endOfTime;
   return time;
 }
 


### PR DESCRIPTION
Fixed a bug where ticket number in the event title wasn't being considered if the event description was empty.
Removed the timezone modifier from the event time format, which Jira was incorrectly using to push events into the previous day in my timezone (Melbourne, Australia - UTC+1000).
Made it so that events with zero duration are not logged by default.